### PR TITLE
Add headless Brazilian coins collection builder and app integration

### DIFF
--- a/OpenNumismat/MainWindow.py
+++ b/OpenNumismat/MainWindow.py
@@ -157,6 +157,11 @@ class MainWindow(QMainWindow):
         openCollectionAct.setShortcut(QKeySequence.Open)
         openCollectionAct.triggered.connect(self.openCollectionEvent)
 
+        openBrazilCollectionAct = QAction(
+            self.tr("Open built-in Brazilian coins collection"), self)
+        openBrazilCollectionAct.triggered.connect(
+            self.openBrazilCollectionEvent)
+
         backupCollectionAct = QAction(
                                     QIcon(':/database_backup.png'),
                                     self.tr("Backup"), self)
@@ -272,6 +277,7 @@ class MainWindow(QMainWindow):
 
         file.addAction(newCollectionAct)
         file.addAction(openCollectionAct)
+        file.addAction(openBrazilCollectionAct)
         file.addSeparator()
         file.addAction(backupCollectionAct)
         file.addAction(vacuumCollectionAct)
@@ -806,6 +812,33 @@ class MainWindow(QMainWindow):
                 self.tr("Collections (*.db)"))
         if fileName:
             self.openCollection(fileName)
+
+    def openBrazilCollectionEvent(self):
+        # The Brazilian coins collection is bundled read-only with the
+        # application (built offline via tools/build_brazil_collection.py).
+        # Copy it into the user's home folder on first use so it stays
+        # editable, then open that writable copy.
+        import os
+        import shutil
+        import OpenNumismat
+
+        src = os.path.join(OpenNumismat.PRJ_PATH, 'db', 'brazil_coins.db')
+        if not os.path.exists(src):
+            QMessageBox.information(self, self.tr("Brazilian coins"),
+                self.tr("The built-in Brazilian coins collection is not "
+                        "available in this installation."))
+            return
+
+        dst = os.path.join(OpenNumismat.HOME_PATH, 'brazil_coins.db')
+        if not os.path.exists(dst):
+            try:
+                os.makedirs(OpenNumismat.HOME_PATH, exist_ok=True)
+                shutil.copy(src, dst)
+            except OSError:
+                # Fall back to opening the bundled file directly.
+                dst = src
+
+        self.openCollection(dst)
 
     def newCollectionEvent(self):
         fileName, _selectedFilter = QFileDialog.getSaveFileName(self,

--- a/OpenNumismat/resources/i18n/lang.ts
+++ b/OpenNumismat/resources/i18n/lang.ts
@@ -2328,6 +2328,18 @@ drag-n-drop to add an image)</source>
 <context>
     <name>MainWindow</name>
     <message>
+        <source>Open built-in Brazilian coins collection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Brazilian coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The built-in Brazilian coins collection is not available in this installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Table view</source>
         <translation type="unfinished"></translation>
     </message>

--- a/OpenNumismat/resources/i18n/lang_pt.ts
+++ b/OpenNumismat/resources/i18n/lang_pt.ts
@@ -2341,6 +2341,18 @@ arraste e largue para adicionar)</translation>
 <context>
     <name>MainWindow</name>
     <message>
+        <source>Open built-in Brazilian coins collection</source>
+        <translation>Abrir colecção interna de moedas brasileiras</translation>
+    </message>
+    <message>
+        <source>Brazilian coins</source>
+        <translation>Moedas brasileiras</translation>
+    </message>
+    <message>
+        <source>The built-in Brazilian coins collection is not available in this installation.</source>
+        <translation>A colecção interna de moedas brasileiras não está disponível nesta instalação.</translation>
+    </message>
+    <message>
         <source>Table view</source>
         <translation>Vista Tabela</translation>
     </message>

--- a/tools/README_brazil_coins.md
+++ b/tools/README_brazil_coins.md
@@ -1,0 +1,56 @@
+# Brazilian coins collection
+
+OpenNumismat is a collection *manager*: it does not ship catalogue data of its
+own. To make a ready-to-use set of Brazilian coins available out of the box, a
+bundled collection database can be generated from the
+[Colnect](https://colnect.com/) catalogue using the existing in-app importer,
+then committed so it ships with the application.
+
+## How it works
+
+* `tools/build_brazil_collection.py` is a **headless** builder. It reuses the
+  exact code path behind the in-app *File → Import → Colnect* dialog
+  (`ColnectConnector`): it looks up Brazil's Colnect country id, enumerates
+  every Brazilian coin type, fetches each one, and writes the records into a new
+  collection database.
+* The output is intended to be committed as
+  `OpenNumismat/db/brazil_coins.db`. The whole `OpenNumismat/db` folder is
+  already included by the build specs (`open-numismat.spec`, `setup.py`), so no
+  packaging changes are needed.
+* In the app, **File → Open built-in Brazilian coins collection** copies the
+  bundled database into the user's home folder (so it stays editable) and opens
+  it.
+
+## Generating the database
+
+The builder must run on a machine that has:
+
+1. OpenNumismat's runtime dependencies (`pip install -r requirements.txt`),
+   notably PySide6.
+2. `OpenNumismat/private_keys.py` providing `COLNECT_PROXY` and `COLNECT_KEY`.
+   Without it the Colnect importer reports itself unavailable.
+3. Outbound network access to the Colnect proxy and image CDN.
+
+```sh
+python3 tools/build_brazil_collection.py \
+    --output OpenNumismat/db/brazil_coins.db \
+    --since 1800
+```
+
+Options:
+
+| Option      | Default                          | Meaning                                   |
+| ----------- | -------------------------------- | ----------------------------------------- |
+| `--output`  | `OpenNumismat/db/brazil_coins.db`| Collection database to create             |
+| `--since`   | `1800`                           | Skip coins issued before this year        |
+| `--locale`  | `en`                             | Catalogue language passed to Colnect      |
+| `--force`   | off                              | Overwrite an existing output file         |
+
+The script runs Qt with the `offscreen` platform plugin (no display required)
+and silences the importer's modal warning dialogs so a rate-limit or transient
+error never blocks an unattended run.
+
+After generating the file, review it (open it in OpenNumismat) and commit it.
+
+> **Note:** the build cannot be run in environments where `colnect.com` is
+> blocked by egress policy or where Colnect API keys are unavailable.

--- a/tools/build_brazil_collection.py
+++ b/tools/build_brazil_collection.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Build a bundled OpenNumismat collection of Brazilian coins from Colnect.
+
+This is a *headless* builder: it reuses OpenNumismat's existing Colnect import
+machinery (the same code path used by the in-app "Import -> Colnect" dialog) to
+enumerate every Brazilian coin in the Colnect catalogue and write the records
+into a fresh collection database. The resulting file is meant to be committed as
+``OpenNumismat/db/brazil_coins.db`` so it ships with the application and can be
+opened from "File -> Open built-in Brazilian coins collection".
+
+Requirements (must be satisfied on the machine that runs this script):
+
+* OpenNumismat's runtime dependencies installed (``pip install -r
+  requirements.txt``) -- in particular PySide6.
+* ``OpenNumismat/private_keys.py`` providing ``COLNECT_PROXY`` and
+  ``COLNECT_KEY``. Without it the Colnect importer reports itself unavailable
+  and this script cannot fetch anything.
+* Outbound network access to the Colnect proxy and image CDN.
+
+The script runs Qt with the ``offscreen`` platform plugin so no display is
+needed, and it silences the importer's modal warning dialogs so a rate-limit or
+transient error never blocks an unattended run.
+
+Example::
+
+    python3 tools/build_brazil_collection.py \
+        --output OpenNumismat/db/brazil_coins.db --since 1800
+
+Re-running with an existing output file requires ``--force`` (the file is
+removed and rebuilt from scratch).
+"""
+
+import argparse
+import os
+import sys
+
+# Qt needs a platform plugin even when we never show a window. "offscreen"
+# keeps the whole run headless. Set before any PySide6 import.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+# Make the OpenNumismat package importable when run from a source checkout.
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+
+def _find_brazil(countries):
+    """Return Colnect's country id for Brazil from a getCountries() result.
+
+    Each entry is ``[id, name, has_coins]``. Match on the localised name; fall
+    back to a case-insensitive English/Portuguese spelling.
+    """
+    for country in countries:
+        if len(country) >= 2 and isinstance(country[1], str):
+            name = country[1].strip().lower()
+            if name in ("brazil", "brasil"):
+                return country[0], country[1]
+    return None, None
+
+
+def build(output, since, category, locale):
+    from PySide6.QtWidgets import QApplication, QMessageBox
+
+    # A QApplication is required for the Qt SQL / model layer and for the
+    # importer's cursor handling, even in offscreen mode.
+    app = QApplication.instance() or QApplication(sys.argv)
+
+    # The importer pops modal QMessageBox warnings on API errors / rate limits.
+    # In an unattended build those would hang forever, so route them to stderr.
+    def _quiet_message(parent=None, title="", text="", *args, **kwargs):
+        print(f"[colnect] {title}: {text}", file=sys.stderr)
+        return QMessageBox.StandardButton.Ok
+
+    QMessageBox.warning = staticmethod(_quiet_message)
+    QMessageBox.critical = staticmethod(_quiet_message)
+    QMessageBox.information = staticmethod(_quiet_message)
+
+    import OpenNumismat
+    from OpenNumismat.pathes import init_pathes
+    init_pathes()
+
+    from OpenNumismat.Settings import Settings
+    settings = Settings()
+    # Pull catalogue text in the requested language where Colnect supports it.
+    settings['colnect_locale'] = locale
+
+    from OpenNumismat.Collection.Import.Colnect import (
+        ColnectConnector, colnectAvailable)
+    if not colnectAvailable:
+        sys.exit(
+            "Colnect import is unavailable: create OpenNumismat/private_keys.py "
+            "with COLNECT_PROXY and COLNECT_KEY before running this builder.")
+
+    from OpenNumismat.Collection.Collection import Collection
+
+    if os.path.exists(output):
+        sys.exit(f"Output already exists: {output} (use --force to overwrite)")
+
+    out_dir = os.path.dirname(os.path.abspath(output))
+    os.makedirs(out_dir, exist_ok=True)
+
+    collection = Collection()
+    if not collection.create(output):
+        sys.exit(f"Could not create collection database at {output}")
+    model = collection.model()
+
+    connector = ColnectConnector(None)
+    try:
+        countries = connector.getCountries("coins")
+        country_id, country_name = _find_brazil(countries)
+        if country_id is None:
+            sys.exit("Could not locate Brazil in Colnect's country list.")
+        print(f"Brazil -> Colnect country id {country_id} ({country_name})")
+
+        item_ids = connector.getIds("coins", country_id)
+        if not item_ids:
+            sys.exit("Colnect returned no Brazilian coins (check keys / limits).")
+        print(f"Found {len(item_ids)} Brazilian coin types in the catalogue.")
+
+        fields = connector.getFields("coins")
+
+        added = 0
+        skipped_year = 0
+        failed = 0
+        for i, item_id in enumerate(item_ids, start=1):
+            action = f"item/cat/coins/id/{item_id}"
+            data = connector.getData(action)
+            if not data or len(data) != len(fields):
+                failed += 1
+                continue
+
+            # makeItem expects the item URL appended as the final column.
+            data.append(f"https://colnect.com/{locale}/coins/coin/{item_id}")
+
+            record = model.record()
+            connector.makeItem("coins", data, record)
+
+            # "since the 1800s" -- skip anything we can date earlier than --since.
+            year = record.value("year")
+            try:
+                if year not in (None, "") and int(year) < since:
+                    skipped_year += 1
+                    continue
+            except (TypeError, ValueError):
+                pass  # keep undated coins
+
+            model.appendRecord(record)
+            added += 1
+
+            if i % 50 == 0:
+                print(f"  ...processed {i}/{len(item_ids)} "
+                      f"(added {added}, skipped {skipped_year}, failed {failed})")
+
+        model.submitAll()
+    finally:
+        connector.close()
+
+    print(f"Done. Added {added} coins to {output} "
+          f"(skipped {skipped_year} pre-{since}, {failed} fetch failures).")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--output", "-o",
+        default=os.path.join(REPO_ROOT, "OpenNumismat", "db", "brazil_coins.db"),
+        help="Path of the collection database to create "
+             "(default: OpenNumismat/db/brazil_coins.db)")
+    parser.add_argument(
+        "--since", type=int, default=1800,
+        help="Skip coins issued before this year (default: 1800)")
+    parser.add_argument(
+        "--locale", default="en",
+        help="Catalogue language passed to Colnect (default: en)")
+    parser.add_argument(
+        "--force", action="store_true",
+        help="Overwrite the output file if it already exists")
+    args = parser.parse_args()
+
+    if args.force and os.path.exists(args.output):
+        os.remove(args.output)
+
+    build(args.output, args.since, "coins", args.locale)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add tools/build_brazil_collection.py, a headless builder that drives the
existing Colnect importer (ColnectConnector) to enumerate every Brazilian
coin type and write it into a bundled collection database
(OpenNumismat/db/brazil_coins.db). It runs Qt offscreen and silences the
importer's modal dialogs so it can run unattended; coins issued before a
configurable year (default 1800) are skipped.

Add a "File -> Open built-in Brazilian coins collection" action in
MainWindow that copies the bundled database into the user's home folder
and opens it, falling back gracefully when the database is absent.

Document the workflow and its key/network requirements in
tools/README_brazil_coins.md.