### PR TITLE
Export Money and Value fields as numbers in Excel (#253)

### DIFF
--- a/OpenNumismat/ListView.py
+++ b/OpenNumismat/ListView.py
@@ -311,6 +311,16 @@ class BaseTableView(QTableView):
 
                     if value is None:
                         parts.append('')
+                    elif (export.acceptNumbers()
+                            and field.type in (Type.Money, Type.Value)):
+                        # Export monetary/numeric fields as real numbers so
+                        # spreadsheets can sum and sort them (#253). Fall back
+                        # to the display string if the raw value isn't numeric.
+                        raw = model.data(field_index, Qt.UserRole)
+                        try:
+                            parts.append(float(raw))
+                        except (TypeError, ValueError):
+                            parts.append(value)
                     else:
                         parts.append(value)
 

--- a/OpenNumismat/Reports/ExportList.py
+++ b/OpenNumismat/Reports/ExportList.py
@@ -29,6 +29,9 @@ class __ExportBase():
     def acceptImages(self):
         return False
 
+    def acceptNumbers(self):
+        return False
+
 
 class ExportToExcel(__ExportBase):
 
@@ -76,6 +79,9 @@ class ExportToExcel(__ExportBase):
         self._current_row += 1
 
     def acceptImages(self):
+        return True
+
+    def acceptNumbers(self):
         return True
 
 


### PR DESCRIPTION
## Problem

Fixes #253. When exporting a coin list to Excel, numeric columns (price, precious-metal weight) are written as **text** cells, so a spreadsheet cannot `SUM()` or sort them.

Root cause: the export loop feeds openpyxl the localized `Qt.DisplayRole` string for every field, so `12.5` is stored as the string `"12.5"`.

## Reproduction

Driving the existing `ExportToExcel` with a row of display strings (as `ListView` does today), then reading the cell types back (`'s'` = text, `'n'` = number):

```
'Half Dollar':s | '12.5':s | '31.103':s | '2020':s
```

Every value cell is text.

## Fix

- Add `acceptNumbers()` to the exporter classes (returns `True` only for `ExportToExcel`).
- In the export loop, for `Money` and `Value` fields when the exporter accepts numbers, pass the raw numeric value (`Qt.UserRole`) instead of the display string, falling back to the string if it is not numeric.
- CSV and HTML exports are unchanged; they keep their formatted display strings.

## After

```
'Half Dollar':s | 12.5:n | 31.103:n | '2020':s
```

Price and weight are now real numbers. `Year` is intentionally left as text because it carries formatting such as "100 BC", and the title stays text. `acceptNumbers()` is `True` for Excel and `False` for HTML/CSV/CSV-UTF8, so only the spreadsheet export is affected.

I scoped this to `Money` and `Value` (the numeric fields in the report). It could extend to `BigInt` (for example mintage) if you would like that too; I left it out to keep the change focused.

---

Written with AI assistance; I've reviewed and tested the change and will maintain it.
